### PR TITLE
#1179 fix: notifications can be enabled now

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="com.termux.permission.RUN_COMMAND" />


### PR DESCRIPTION
After adding `POST_NOTIFICATIONS` permission in AndroidManifest, I was able to turn on the notifications again.

##### Expected behavior
- [x] In notification page of system's settings, there should be KeyMapper even without choosing "all system apps".
- [x] I should be able to turn on Pause/Resume mappings notifications in app's settings.
- [x] I should be able to Toggle Key Mapper keyboard with notification.

Tested on
- [x] Galaxy Tab S7 FE
- [x] Galaxy S23