### PR TITLE
Add mapping for Sony Xperia 5 III assistant button to KEY_ASSIST

### DIFF
--- a/system/src/main/java/io/github/sds100/keymapper/system/inputevents/InputEventUtils.kt
+++ b/system/src/main/java/io/github/sds100/keymapper/system/inputevents/InputEventUtils.kt
@@ -333,6 +333,9 @@ object InputEventUtils {
         "02bf" to KeyEvent.KEYCODE_MENU,
         "02bf" to KeyEvent.KEYCODE_ASSIST,
 
+        // Xperia 5 III assistant button
+        "01c9" to KeyEvent.KEYCODE_ASSIST,
+
         "KEY_SEARCH" to KeyEvent.KEYCODE_SEARCH,
     )
 


### PR DESCRIPTION
Adds the button ID as recorded by `getevent -lq` so the assistant button can be monitored while the screen is off. I do not know if this button ID is used on models besides the Sony Xperia 5 III.