### PR TITLE
Simplify ShortcutButton layout and text constraints

### DIFF
--- a/base/src/main/java/io/github/sds100/keymapper/base/trigger/TriggerDiscoverScreen.kt
+++ b/base/src/main/java/io/github/sds100/keymapper/base/trigger/TriggerDiscoverScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -208,7 +207,7 @@ private fun ShortcutButton(
     onClick: () -> Unit,
 ) {
     Column(
-        modifier = modifier.widthIn(max = 56.dp),
+        modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
@@ -235,7 +234,7 @@ private fun ShortcutButton(
             style = MaterialTheme.typography.labelMedium,
             textAlign = TextAlign.Center,
             color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 2,
+            maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
     }


### PR DESCRIPTION
## Summary
Simplified the `ShortcutButton` composable by removing width constraints and adjusting text display behavior for improved layout flexibility.

## Key Changes
- Removed `widthIn(max = 56.dp)` modifier constraint from the Column layout
- Changed text `maxLines` from 2 to 1 for single-line display
- Removed unused `widthIn` import

## Implementation Details
These changes allow the ShortcutButton to size itself more naturally based on content rather than being constrained to a fixed maximum width. The text will now display on a single line with ellipsis overflow, providing a cleaner and more predictable appearance.

https://claude.ai/code/session_01W3yFTWbyc9dxMPumNUhsS8