### PR TITLE
#2106 fix: show dialog when using in-app keyboard switcher to disable auto-switch

### DIFF
--- a/base/src/main/java/io/github/sds100/keymapper/base/actions/keyevent/FixKeyEventActionDelegate.kt
+++ b/base/src/main/java/io/github/sds100/keymapper/base/actions/keyevent/FixKeyEventActionDelegate.kt
@@ -63,10 +63,6 @@ class FixKeyEventActionDelegateImpl @Inject constructor(
         preferenceRepository.get(Keys.keyEventActionsUseSystemBridge)
             .map { it ?: PreferenceDefaults.KEY_EVENT_ACTIONS_USE_SYSTEM_BRIDGE }
 
-    override val isAutoSwitchImeEnabled: Flow<Boolean> =
-        preferenceRepository.get(Keys.changeImeOnInputFocus)
-            .map { it ?: PreferenceDefaults.CHANGE_IME_ON_INPUT_FOCUS }
-
     private val showBottomSheet: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -170,7 +166,6 @@ class FixKeyEventActionDelegateImpl @Inject constructor(
 
 interface FixKeyEventActionDelegate {
     val fixKeyEventActionState: StateFlow<FixKeyEventActionState?>
-    val isAutoSwitchImeEnabled: Flow<Boolean>
 
     fun showFixKeyEventActionBottomSheet()
     fun dismissFixKeyEventActionBottomSheet()

--- a/base/src/main/java/io/github/sds100/keymapper/base/actions/keyevent/FixKeyEventActionDelegate.kt
+++ b/base/src/main/java/io/github/sds100/keymapper/base/actions/keyevent/FixKeyEventActionDelegate.kt
@@ -63,6 +63,10 @@ class FixKeyEventActionDelegateImpl @Inject constructor(
         preferenceRepository.get(Keys.keyEventActionsUseSystemBridge)
             .map { it ?: PreferenceDefaults.KEY_EVENT_ACTIONS_USE_SYSTEM_BRIDGE }
 
+    override val isAutoSwitchImeEnabled: Flow<Boolean> =
+        preferenceRepository.get(Keys.changeImeOnInputFocus)
+            .map { it ?: PreferenceDefaults.CHANGE_IME_ON_INPUT_FOCUS }
+
     private val showBottomSheet: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -166,6 +170,7 @@ class FixKeyEventActionDelegateImpl @Inject constructor(
 
 interface FixKeyEventActionDelegate {
     val fixKeyEventActionState: StateFlow<FixKeyEventActionState?>
+    val isAutoSwitchImeEnabled: Flow<Boolean>
 
     fun showFixKeyEventActionBottomSheet()
     fun dismissFixKeyEventActionBottomSheet()

--- a/base/src/main/java/io/github/sds100/keymapper/base/home/KeyMapListViewModel.kt
+++ b/base/src/main/java/io/github/sds100/keymapper/base/home/KeyMapListViewModel.kt
@@ -908,7 +908,7 @@ class KeyMapListViewModel(
 
     fun showInputMethodPicker() {
         coroutineScope.launch {
-            val autoSwitchEnabled = isAutoSwitchImeEnabled.first()
+            val autoSwitchEnabled = showInputMethodPickerUseCase.isAutoSwitchImeEnabled.first()
 
             if (autoSwitchEnabled) {
                 val response = showDialog(
@@ -923,7 +923,7 @@ class KeyMapListViewModel(
 
                 if (response != DialogResponse.POSITIVE) return@launch
 
-                onAutoSwitchImeCheckedChange(false)
+                showInputMethodPickerUseCase.disableAutoSwitch()
             }
 
             showInputMethodPickerUseCase.show(fromForeground = true)

--- a/base/src/main/java/io/github/sds100/keymapper/base/home/KeyMapListViewModel.kt
+++ b/base/src/main/java/io/github/sds100/keymapper/base/home/KeyMapListViewModel.kt
@@ -907,7 +907,27 @@ class KeyMapListViewModel(
     }
 
     fun showInputMethodPicker() {
-        showInputMethodPickerUseCase.show(fromForeground = true)
+        coroutineScope.launch {
+            val autoSwitchEnabled = isAutoSwitchImeEnabled.first()
+
+            if (autoSwitchEnabled) {
+                val response = showDialog(
+                    "disable_auto_switch_ime_dialog",
+                    DialogModel.Alert(
+                        title = getString(R.string.dialog_title_disable_auto_switch_ime),
+                        message = getString(R.string.dialog_message_disable_auto_switch_ime),
+                        positiveButtonText = getString(R.string.pos_ok),
+                        negativeButtonText = getString(R.string.neg_cancel),
+                    ),
+                )
+
+                if (response != DialogResponse.POSITIVE) return@launch
+
+                onAutoSwitchImeCheckedChange(false)
+            }
+
+            showInputMethodPickerUseCase.show(fromForeground = true)
+        }
     }
 
     private suspend fun onAutomaticBackupResult(result: KMResult<*>) {

--- a/base/src/main/java/io/github/sds100/keymapper/base/system/inputmethod/ShowInputMethodPickerUseCase.kt
+++ b/base/src/main/java/io/github/sds100/keymapper/base/system/inputmethod/ShowInputMethodPickerUseCase.kt
@@ -1,16 +1,33 @@
 package io.github.sds100.keymapper.base.system.inputmethod
 
+import io.github.sds100.keymapper.data.Keys
+import io.github.sds100.keymapper.data.PreferenceDefaults
+import io.github.sds100.keymapper.data.repositories.PreferenceRepository
 import io.github.sds100.keymapper.system.inputmethod.InputMethodAdapter
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 class ShowInputMethodPickerUseCaseImpl @Inject constructor(
     private val inputMethodAdapter: InputMethodAdapter,
+    private val preferenceRepository: PreferenceRepository,
 ) : ShowInputMethodPickerUseCase {
+    override val isAutoSwitchImeEnabled: Flow<Boolean> =
+        preferenceRepository.get(Keys.changeImeOnInputFocus)
+            .map { it ?: PreferenceDefaults.CHANGE_IME_ON_INPUT_FOCUS }
+
+    override fun disableAutoSwitch() {
+        preferenceRepository.set(Keys.changeImeOnInputFocus, false)
+    }
+
     override fun show(fromForeground: Boolean) {
         inputMethodAdapter.showImePicker(fromForeground = fromForeground)
     }
 }
 
 interface ShowInputMethodPickerUseCase {
+    val isAutoSwitchImeEnabled: Flow<Boolean>
+
+    fun disableAutoSwitch()
     fun show(fromForeground: Boolean)
 }

--- a/base/src/main/res/values/strings.xml
+++ b/base/src/main/res/values/strings.xml
@@ -1901,4 +1901,7 @@
     <string name="dialog_bug_report_discord_button">Open Discord</string>
     <string name="dialog_bug_report_email_button">Email us</string>
 
+    <string name="dialog_title_disable_auto_switch_ime">Disable auto-switch keyboard?</string>
+    <string name="dialog_message_disable_auto_switch_ime">Choosing a keyboard here will disable the automatic keyboard switching feature. You can re-enable it in Settings.</string>
+
 </resources>


### PR DESCRIPTION
Closes #2106

## Summary

- When the user taps **"Choose keyboard"** from the home screen menu and the **automatic keyboard switching** feature is currently enabled, a dialog is shown warning that choosing a keyboard here will disable the auto-switch feature
- If the user confirms (OK), auto-switch is disabled and the IME picker opens
- If the user cancels, nothing happens — auto-switch stays on and the picker is not shown
- If auto-switch is already disabled, the IME picker opens immediately as before

This prevents the confusing experience where a user manually selects a keyboard from the IME picker, only to have KeyMapper immediately switch back to its own IME via the auto-switch feature.

## Changes

| File | Change |
|------|--------|
| `FixKeyEventActionDelegate.kt` | Added `isAutoSwitchImeEnabled: Flow<Boolean>` to the interface and implementation, reading from the `changeImeOnInputFocus` preference |
| `KeyMapListViewModel.kt` | `showInputMethodPicker()` now launches a coroutine, checks whether auto-switch is on, shows the confirmation dialog if so, disables the feature on confirm, then shows the IME picker |
| `strings.xml` | Added `dialog_title_disable_auto_switch_ime` and `dialog_message_disable_auto_switch_ime` strings |

https://claude.ai/code/session_01AdijnJnpbsCqPDTYobwnLa