### PR TITLE
#2107 clarify accessibility restart dialog copy and actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Fixed
 
 - #2091 show an error on the "open device assistant" action when no device assistant is installed.
+- #2107 clarify the crashed accessibility service dialog text and keep only Cancel/Restart actions.
 
 ## [4.0.5](https://github.com/sds100/KeyMapper/releases/tag/v4.0.5)
 

--- a/base/src/main/java/io/github/sds100/keymapper/base/onboarding/SetupAccessibilityServiceDialog.kt
+++ b/base/src/main/java/io/github/sds100/keymapper/base/onboarding/SetupAccessibilityServiceDialog.kt
@@ -1,10 +1,8 @@
 package io.github.sds100.keymapper.base.onboarding
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -41,15 +39,10 @@ fun HandleAccessibilityServiceDialogs(delegate: SetupAccessibilityServiceDelegat
         }
 
         is AccessibilityServiceDialog.RestartService -> {
-            val dontKillMyAppUrl = stringResource(R.string.url_dont_kill_my_app)
             RestartAccessibilityServiceDialog(
                 modifier = Modifier,
                 onDismissRequest = delegate::onCancelClick,
                 onRestartClick = delegate::onRestartServiceClick,
-                onDontKillMyAppClick = {
-                    uriHandler.openUriSafe(context, dontKillMyAppUrl)
-                },
-                onIgnoreClick = delegate::onIgnoreCrashedClick,
             )
         }
 
@@ -113,8 +106,6 @@ private fun RestartAccessibilityServiceDialog(
     modifier: Modifier = Modifier,
     onDismissRequest: () -> Unit,
     onRestartClick: () -> Unit,
-    onDontKillMyAppClick: () -> Unit,
-    onIgnoreClick: () -> Unit,
 ) {
     AlertDialog(
         modifier = modifier,
@@ -129,19 +120,13 @@ private fun RestartAccessibilityServiceDialog(
             )
         },
         confirmButton = {
-            Row {
-                TextButton(onClick = onRestartClick) {
-                    Text(stringResource(R.string.pos_restart))
-                }
-                Spacer(modifier = Modifier.width(8.dp))
-                TextButton(onClick = onDontKillMyAppClick) {
-                    Text(stringResource(R.string.dialog_button_read_dont_kill_my_app_yes))
-                }
+            TextButton(onClick = onRestartClick) {
+                Text(stringResource(R.string.pos_restart))
             }
         },
         dismissButton = {
-            TextButton(onClick = onIgnoreClick) {
-                Text(stringResource(R.string.dialog_button_read_dont_kill_my_app_no))
+            TextButton(onClick = onDismissRequest) {
+                Text(stringResource(R.string.neg_cancel))
             }
         },
     )
@@ -238,8 +223,6 @@ private fun RestartAccessibilityServiceDialogPreview() {
         RestartAccessibilityServiceDialog(
             onDismissRequest = {},
             onRestartClick = {},
-            onDontKillMyAppClick = {},
-            onIgnoreClick = {},
         )
     }
 }

--- a/base/src/main/res/values/strings.xml
+++ b/base/src/main/res/values/strings.xml
@@ -460,8 +460,8 @@
     <string name="dialog_message_restart_accessibility_service">Restart the accessibility service by turning it <i>off</i> and <i>on</i>.</string>
 
 
-    <string name="dialog_title_key_mapper_crashed">Key Mapper was interrupted</string>
-    <string name="dialog_message_key_mapper_crashed">Key Mapper tried to run in the background but was stopped by the system.\nThis can happen if you have battery or memory optimization turned on.\n\nTo fix this, you can try following an online guide. You should also restart the service when you\'re done.</string>
+    <string name="dialog_title_key_mapper_crashed">Accessibility service needs restarting</string>
+    <string name="dialog_message_key_mapper_crashed">Key Mapper\'s accessibility service was stopped by the system.\n\nTo fix this, restart it by turning the accessibility service off and then on again.</string>
     <string name="dialog_button_read_dont_kill_my_app_yes">Proceed</string>
     <string name="dialog_button_read_dont_kill_my_app_no">Ignore</string>
 


### PR DESCRIPTION
## Summary
- update the crashed accessibility restart dialog text to explicitly instruct turning the service off and on again
- simplify the restart dialog actions to only `Cancel` and `Restart`
- keep existing restart wiring and fallback behavior unchanged

## Test plan
- [ ] trigger the crashed accessibility warning and tap `Fix`
- [ ] verify the dialog copy explains turning accessibility off and on
- [ ] verify only `Cancel` and `Restart` actions are shown
- [ ] verify tapping `Restart` still follows existing restart behavior