### PR TITLE
Improve accessibility of list items for Talkback screen reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+## Changed
+
+- #1369 Add content descriptions to drag handles and custom "Move up"/"Move down" accessibility actions for trigger and action list items, improving TalkBack support for reordering.
+
 ## [4.1.1](https://github.com/sds100/KeyMapper/releases/tag/v4.1.1)
 
 #### 15 May 2026

--- a/base/src/main/java/io/github/sds100/keymapper/base/actions/ActionListItem.kt
+++ b/base/src/main/java/io/github/sds100/keymapper/base/actions/ActionListItem.kt
@@ -39,6 +39,9 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -62,10 +65,15 @@ fun ActionListItem(
     onRemoveClick: () -> Unit = {},
     onFixClick: () -> Unit = {},
     onTestClick: () -> Unit = {},
+    onMoveUp: (() -> Unit)? = null,
+    onMoveDown: (() -> Unit)? = null,
 ) {
     val draggableState = rememberDraggableState {
         dragDropState?.onDrag(Offset(0f, it))
     }
+
+    val moveUpLabel = stringResource(R.string.accessibility_action_move_up)
+    val moveDownLabel = stringResource(R.string.accessibility_action_move_down)
 
     Column(modifier = modifier.fillMaxWidth()) {
         ElevatedCard(
@@ -83,7 +91,19 @@ fun ActionListItem(
                         dragDropState?.onDragStart(index, offset)
                     },
                     onDragStopped = { dragDropState?.onDragInterrupted() },
-                ),
+                )
+                .semantics {
+                    if (isReorderingEnabled) {
+                        customActions = buildList {
+                            onMoveUp?.let { action ->
+                                add(CustomAccessibilityAction(moveUpLabel) { action(); true })
+                            }
+                            onMoveDown?.let { action ->
+                                add(CustomAccessibilityAction(moveDownLabel) { action(); true })
+                            }
+                        }
+                    }
+                },
             colors = CardDefaults.elevatedCardColors(
                 containerColor = if (isDragging) {
                     MaterialTheme.colorScheme.surfaceContainerHighest
@@ -102,7 +122,7 @@ fun ActionListItem(
                     Icon(
                         modifier = Modifier.size(24.dp),
                         imageVector = Icons.Rounded.DragHandle,
-                        contentDescription = null,
+                        contentDescription = stringResource(R.string.drag_handle_for, model.text),
                         tint = MaterialTheme.colorScheme.onSurface,
                     )
                 }

--- a/base/src/main/java/io/github/sds100/keymapper/base/actions/ActionListItem.kt
+++ b/base/src/main/java/io/github/sds100/keymapper/base/actions/ActionListItem.kt
@@ -96,10 +96,20 @@ fun ActionListItem(
                     if (isReorderingEnabled) {
                         customActions = buildList {
                             onMoveUp?.let { action ->
-                                add(CustomAccessibilityAction(moveUpLabel) { action(); true })
+                                add(
+                                    CustomAccessibilityAction(moveUpLabel) {
+                                        action()
+                                        true
+                                    },
+                                )
                             }
                             onMoveDown?.let { action ->
-                                add(CustomAccessibilityAction(moveDownLabel) { action(); true })
+                                add(
+                                    CustomAccessibilityAction(moveDownLabel) {
+                                        action()
+                                        true
+                                    },
+                                )
                             }
                         }
                     }

--- a/base/src/main/java/io/github/sds100/keymapper/base/actions/ActionsScreen.kt
+++ b/base/src/main/java/io/github/sds100/keymapper/base/actions/ActionsScreen.kt
@@ -314,6 +314,16 @@ private fun ActionList(
                     onRemoveClick = { onRemoveClick(model.id) },
                     onFixClick = { onFixErrorClick(model.id) },
                     onTestClick = { onTestClick(model.id) },
+                    onMoveUp = if (isReorderingEnabled && index > 0) {
+                        { onMove(index, index - 1) }
+                    } else {
+                        null
+                    },
+                    onMoveDown = if (isReorderingEnabled && index < actionList.size - 1) {
+                        { onMove(index, index + 1) }
+                    } else {
+                        null
+                    },
                 )
             }
         }

--- a/base/src/main/java/io/github/sds100/keymapper/base/trigger/BaseTriggerScreen.kt
+++ b/base/src/main/java/io/github/sds100/keymapper/base/trigger/BaseTriggerScreen.kt
@@ -482,6 +482,16 @@ private fun TriggerList(
                     onEditClick = { onEditClick(model.id) },
                     onRemoveClick = { onRemoveClick(model.id) },
                     onFixClick = onFixErrorClick,
+                    onMoveUp = if (isReorderingEnabled && index > 0) {
+                        { onMove(index, index - 1) }
+                    } else {
+                        null
+                    },
+                    onMoveDown = if (isReorderingEnabled && index < triggerList.size - 1) {
+                        { onMove(index, index + 1) }
+                    } else {
+                        null
+                    },
                 )
             }
         }

--- a/base/src/main/java/io/github/sds100/keymapper/base/trigger/TriggerKeyListItem.kt
+++ b/base/src/main/java/io/github/sds100/keymapper/base/trigger/TriggerKeyListItem.kt
@@ -39,6 +39,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -60,10 +63,66 @@ fun TriggerKeyListItem(
     onEditClick: () -> Unit = {},
     onRemoveClick: () -> Unit = {},
     onFixClick: (TriggerError) -> Unit = {},
+    onMoveUp: (() -> Unit)? = null,
+    onMoveDown: (() -> Unit)? = null,
 ) {
     val draggableState = rememberDraggableState {
         dragDropState?.onDrag(Offset(0f, it))
     }
+
+    val primaryText = when (model) {
+        is TriggerKeyListItemModel.Assistant -> when (model.assistantType) {
+            AssistantTriggerType.ANY -> stringResource(
+                R.string.assistant_any_trigger_name,
+            )
+
+            AssistantTriggerType.VOICE -> stringResource(
+                R.string.assistant_voice_trigger_name,
+            )
+
+            AssistantTriggerType.DEVICE -> stringResource(
+                R.string.assistant_device_trigger_name,
+            )
+        }
+
+        is TriggerKeyListItemModel.FloatingButton -> if (model.buttonName.isBlank()) {
+            stringResource(R.string.trigger_key_floating_button_description_empty)
+        } else {
+            stringResource(
+                R.string.trigger_key_floating_button_description,
+                model.buttonName,
+            )
+        }
+
+        is TriggerKeyListItemModel.KeyEvent -> model.keyName
+
+        is TriggerKeyListItemModel.EvdevEvent -> model.keyName
+
+        is TriggerKeyListItemModel.FloatingButtonDeleted -> stringResource(
+            R.string.trigger_error_floating_button_deleted_title,
+        )
+
+        is TriggerKeyListItemModel.FingerprintGesture -> when (model.gestureType) {
+            FingerprintGestureType.SWIPE_UP -> stringResource(
+                R.string.trigger_key_fingerprint_gesture_up,
+            )
+
+            FingerprintGestureType.SWIPE_DOWN -> stringResource(
+                R.string.trigger_key_fingerprint_gesture_down,
+            )
+
+            FingerprintGestureType.SWIPE_LEFT -> stringResource(
+                R.string.trigger_key_fingerprint_gesture_left,
+            )
+
+            FingerprintGestureType.SWIPE_RIGHT -> stringResource(
+                R.string.trigger_key_fingerprint_gesture_right,
+            )
+        }
+    }
+
+    val moveUpLabel = stringResource(R.string.accessibility_action_move_up)
+    val moveDownLabel = stringResource(R.string.accessibility_action_move_down)
 
     Column(modifier = modifier.fillMaxWidth()) {
         ElevatedCard(
@@ -81,7 +140,19 @@ fun TriggerKeyListItem(
                         dragDropState?.onDragStart(index, offset)
                     },
                     onDragStopped = { dragDropState?.onDragInterrupted() },
-                ),
+                )
+                .semantics {
+                    if (isReorderingEnabled) {
+                        customActions = buildList {
+                            onMoveUp?.let { action ->
+                                add(CustomAccessibilityAction(moveUpLabel) { action(); true })
+                            }
+                            onMoveDown?.let { action ->
+                                add(CustomAccessibilityAction(moveDownLabel) { action(); true })
+                            }
+                        }
+                    }
+                },
             colors = CardDefaults.elevatedCardColors(
                 containerColor = if (isDragging) {
                     MaterialTheme.colorScheme.surfaceContainerHighest
@@ -100,7 +171,7 @@ fun TriggerKeyListItem(
                     Icon(
                         modifier = Modifier.size(24.dp),
                         imageVector = Icons.Rounded.DragHandle,
-                        contentDescription = null,
+                        contentDescription = stringResource(R.string.drag_handle_for, primaryText),
                         tint = MaterialTheme.colorScheme.onSurface,
                     )
                 }
@@ -123,57 +194,6 @@ fun TriggerKeyListItem(
                             imageVector = icon,
                             contentDescription = null,
                             tint = MaterialTheme.colorScheme.onSurface,
-                        )
-                    }
-                }
-
-                val primaryText = when (model) {
-                    is TriggerKeyListItemModel.Assistant -> when (model.assistantType) {
-                        AssistantTriggerType.ANY -> stringResource(
-                            R.string.assistant_any_trigger_name,
-                        )
-
-                        AssistantTriggerType.VOICE -> stringResource(
-                            R.string.assistant_voice_trigger_name,
-                        )
-
-                        AssistantTriggerType.DEVICE -> stringResource(
-                            R.string.assistant_device_trigger_name,
-                        )
-                    }
-
-                    is TriggerKeyListItemModel.FloatingButton -> if (model.buttonName.isBlank()) {
-                        stringResource(R.string.trigger_key_floating_button_description_empty)
-                    } else {
-                        stringResource(
-                            R.string.trigger_key_floating_button_description,
-                            model.buttonName,
-                        )
-                    }
-
-                    is TriggerKeyListItemModel.KeyEvent -> model.keyName
-
-                    is TriggerKeyListItemModel.EvdevEvent -> model.keyName
-
-                    is TriggerKeyListItemModel.FloatingButtonDeleted -> stringResource(
-                        R.string.trigger_error_floating_button_deleted_title,
-                    )
-
-                    is TriggerKeyListItemModel.FingerprintGesture -> when (model.gestureType) {
-                        FingerprintGestureType.SWIPE_UP -> stringResource(
-                            R.string.trigger_key_fingerprint_gesture_up,
-                        )
-
-                        FingerprintGestureType.SWIPE_DOWN -> stringResource(
-                            R.string.trigger_key_fingerprint_gesture_down,
-                        )
-
-                        FingerprintGestureType.SWIPE_LEFT -> stringResource(
-                            R.string.trigger_key_fingerprint_gesture_left,
-                        )
-
-                        FingerprintGestureType.SWIPE_RIGHT -> stringResource(
-                            R.string.trigger_key_fingerprint_gesture_right,
                         )
                     }
                 }

--- a/base/src/main/java/io/github/sds100/keymapper/base/trigger/TriggerKeyListItem.kt
+++ b/base/src/main/java/io/github/sds100/keymapper/base/trigger/TriggerKeyListItem.kt
@@ -70,56 +70,7 @@ fun TriggerKeyListItem(
         dragDropState?.onDrag(Offset(0f, it))
     }
 
-    val primaryText = when (model) {
-        is TriggerKeyListItemModel.Assistant -> when (model.assistantType) {
-            AssistantTriggerType.ANY -> stringResource(
-                R.string.assistant_any_trigger_name,
-            )
-
-            AssistantTriggerType.VOICE -> stringResource(
-                R.string.assistant_voice_trigger_name,
-            )
-
-            AssistantTriggerType.DEVICE -> stringResource(
-                R.string.assistant_device_trigger_name,
-            )
-        }
-
-        is TriggerKeyListItemModel.FloatingButton -> if (model.buttonName.isBlank()) {
-            stringResource(R.string.trigger_key_floating_button_description_empty)
-        } else {
-            stringResource(
-                R.string.trigger_key_floating_button_description,
-                model.buttonName,
-            )
-        }
-
-        is TriggerKeyListItemModel.KeyEvent -> model.keyName
-
-        is TriggerKeyListItemModel.EvdevEvent -> model.keyName
-
-        is TriggerKeyListItemModel.FloatingButtonDeleted -> stringResource(
-            R.string.trigger_error_floating_button_deleted_title,
-        )
-
-        is TriggerKeyListItemModel.FingerprintGesture -> when (model.gestureType) {
-            FingerprintGestureType.SWIPE_UP -> stringResource(
-                R.string.trigger_key_fingerprint_gesture_up,
-            )
-
-            FingerprintGestureType.SWIPE_DOWN -> stringResource(
-                R.string.trigger_key_fingerprint_gesture_down,
-            )
-
-            FingerprintGestureType.SWIPE_LEFT -> stringResource(
-                R.string.trigger_key_fingerprint_gesture_left,
-            )
-
-            FingerprintGestureType.SWIPE_RIGHT -> stringResource(
-                R.string.trigger_key_fingerprint_gesture_right,
-            )
-        }
-    }
+    val primaryText = getPrimaryText(model)
 
     val moveUpLabel = stringResource(R.string.accessibility_action_move_up)
     val moveDownLabel = stringResource(R.string.accessibility_action_move_down)
@@ -145,10 +96,20 @@ fun TriggerKeyListItem(
                     if (isReorderingEnabled) {
                         customActions = buildList {
                             onMoveUp?.let { action ->
-                                add(CustomAccessibilityAction(moveUpLabel) { action(); true })
+                                add(
+                                    CustomAccessibilityAction(moveUpLabel) {
+                                        action()
+                                        true
+                                    },
+                                )
                             }
                             onMoveDown?.let { action ->
-                                add(CustomAccessibilityAction(moveDownLabel) { action(); true })
+                                add(
+                                    CustomAccessibilityAction(moveDownLabel) {
+                                        action()
+                                        true
+                                    },
+                                )
                             }
                         }
                     }
@@ -299,6 +260,58 @@ fun TriggerKeyListItem(
             )
             Spacer(Modifier.height(4.dp))
         }
+    }
+}
+
+@Composable
+private fun getPrimaryText(model: TriggerKeyListItemModel): String = when (model) {
+    is TriggerKeyListItemModel.Assistant -> when (model.assistantType) {
+        AssistantTriggerType.ANY -> stringResource(
+            R.string.assistant_any_trigger_name,
+        )
+
+        AssistantTriggerType.VOICE -> stringResource(
+            R.string.assistant_voice_trigger_name,
+        )
+
+        AssistantTriggerType.DEVICE -> stringResource(
+            R.string.assistant_device_trigger_name,
+        )
+    }
+
+    is TriggerKeyListItemModel.FloatingButton -> if (model.buttonName.isBlank()) {
+        stringResource(R.string.trigger_key_floating_button_description_empty)
+    } else {
+        stringResource(
+            R.string.trigger_key_floating_button_description,
+            model.buttonName,
+        )
+    }
+
+    is TriggerKeyListItemModel.KeyEvent -> model.keyName
+
+    is TriggerKeyListItemModel.EvdevEvent -> model.keyName
+
+    is TriggerKeyListItemModel.FloatingButtonDeleted -> stringResource(
+        R.string.trigger_error_floating_button_deleted_title,
+    )
+
+    is TriggerKeyListItemModel.FingerprintGesture -> when (model.gestureType) {
+        FingerprintGestureType.SWIPE_UP -> stringResource(
+            R.string.trigger_key_fingerprint_gesture_up,
+        )
+
+        FingerprintGestureType.SWIPE_DOWN -> stringResource(
+            R.string.trigger_key_fingerprint_gesture_down,
+        )
+
+        FingerprintGestureType.SWIPE_LEFT -> stringResource(
+            R.string.trigger_key_fingerprint_gesture_left,
+        )
+
+        FingerprintGestureType.SWIPE_RIGHT -> stringResource(
+            R.string.trigger_key_fingerprint_gesture_right,
+        )
     }
 }
 

--- a/base/src/main/res/values/strings.xml
+++ b/base/src/main/res/values/strings.xml
@@ -486,6 +486,8 @@
     <string name="sorting_drag_and_drop_list_help">Drag the handles to adjust priorities. The item at the top is the most important. You must tap the item to enable sorting and toggle ascending/descending.</string>
     <string name="sorting_drag_and_drop_list_help_example">Example: To sort by Actions (ascending) first and Triggers (descending) second: tap and drag Actions to the first position and set it to ascending, then tap and drag Triggers to the second position and set it to descending.</string>
     <string name="drag_handle_for">Drag handle for %1$s</string>
+    <string name="accessibility_action_move_up">Move up</string>
+    <string name="accessibility_action_move_down">Move down</string>
     <string name="show_example">Show example</string>
 
     <string name="dialog_title_request_notification_permission">Turn on notifications</string>


### PR DESCRIPTION
Closes #1369

## Summary

- **Drag handle content descriptions**: The drag handle icons in trigger key list items and action list items previously had `contentDescription = null`. They now use the existing `drag_handle_for` string resource (e.g. "Drag handle for Volume Up") so TalkBack announces them meaningfully.
- **Custom accessibility actions for reordering**: Added `onMoveUp` and `onMoveDown` parameters to `TriggerKeyListItem` and `ActionListItem`. When reordering is enabled, "Move up" and "Move down" custom accessibility actions are registered via `Modifier.semantics { customActions = ... }` so TalkBack users can reorder items without performing drag gestures. The first item only shows "Move down" and the last item only shows "Move up".
- **New string resources**: `accessibility_action_move_up` ("Move up") and `accessibility_action_move_down` ("Move down") added to `strings.xml`.

## Files changed

- `base/src/main/res/values/strings.xml` — new string resources
- `base/src/main/java/.../trigger/TriggerKeyListItem.kt` — drag handle label + move up/down accessibility actions
- `base/src/main/java/.../actions/ActionListItem.kt` — drag handle label + move up/down accessibility actions
- `base/src/main/java/.../trigger/BaseTriggerScreen.kt` — passes move callbacks to `TriggerKeyListItem`
- `base/src/main/java/.../actions/ActionsScreen.kt` — passes move callbacks to `ActionListItem`
- `CHANGELOG.md` — updated

## Known limitations / areas for human review

- The `SortBottomSheetContent.kt` drag handle already used `drag_handle_for` correctly and was not changed.
- Strings are only provided in English; translations will need to be added for other locales.
- The move actions operate by swapping adjacent items (index ↔ index±1). This matches the existing drag-and-drop behavior, but reviewers should confirm the `onMove` semantics are consistent with how the ViewModel handles reordering.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxGBdEPJmG54Tj9cJqJLRT)_