### PR TITLE
Expert mode warning can be bypassed by going via expert mode debug screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ## Fixed
 
+- #2154 The expert mode debug screen is now only accessible after the expert mode warning has been acknowledged.
 - #2074 Scrolling the action or trigger list no longer accidentally moves items; reordering by drag now only activates from the drag handle or via long-press.
 
 ## Changed

--- a/base/src/main/java/io/github/sds100/keymapper/base/expertmode/ExpertModeScreen.kt
+++ b/base/src/main/java/io/github/sds100/keymapper/base/expertmode/ExpertModeScreen.kt
@@ -252,6 +252,27 @@ private fun Content(
                     )
                 }
             }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            OptionsHeaderRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                icon = Icons.Outlined.BugReport,
+                text = stringResource(R.string.settings_section_debugging_title),
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            OptionPageButton(
+                modifier = Modifier.padding(horizontal = 8.dp),
+                title = stringResource(R.string.title_pref_get_event_debug),
+                text = stringResource(R.string.summary_pref_get_event_debug),
+                icon = Icons.Outlined.BugReport,
+                onClick = onGetEventClick,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
         } else {
             Text(
                 modifier = Modifier.padding(horizontal = 32.dp),
@@ -259,27 +280,6 @@ private fun Content(
                 textAlign = TextAlign.Center,
             )
         }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        OptionsHeaderRow(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-            icon = Icons.Outlined.BugReport,
-            text = stringResource(R.string.settings_section_debugging_title),
-        )
-
-        Spacer(modifier = Modifier.height(8.dp))
-
-        OptionPageButton(
-            modifier = Modifier.padding(horizontal = 8.dp),
-            title = stringResource(R.string.title_pref_get_event_debug),
-            text = stringResource(R.string.summary_pref_get_event_debug),
-            icon = Icons.Outlined.BugReport,
-            onClick = onGetEventClick,
-        )
-        Spacer(modifier = Modifier.height(8.dp))
     }
 }
 

--- a/base/src/main/java/io/github/sds100/keymapper/base/expertmode/ExpertModeViewModel.kt
+++ b/base/src/main/java/io/github/sds100/keymapper/base/expertmode/ExpertModeViewModel.kt
@@ -190,6 +190,7 @@ class ExpertModeViewModel @Inject constructor(
 
     fun onGetEventClick() {
         viewModelScope.launch {
+            if (warningState.value !is ExpertModeWarningState.Understood) return@launch
             navigate("get_event_debug", NavDestination.GetEvent)
         }
     }


### PR DESCRIPTION
Closes #2154

## Summary

- The "Debugging" section (containing the "Expert mode debug" / GetEvent button) was rendered unconditionally in `ExpertModeScreen`, outside the `warningState is Understood` guard that gates all other expert-mode content. This let a user navigate to the GetEvent debug screen without ever acknowledging the expert mode warning.
- **Fix:** Moved the debugging section inside the `if (warningState is ExpertModeWarningState.Understood)` block so the button is only shown once the warning has been acknowledged.
- **Defence-in-depth:** Added an early-return guard in `ExpertModeViewModel.onGetEventClick()` that does nothing if `warningState` is not `Understood`, preventing navigation even if the button were somehow invoked by another code path.

## Files changed

| File | Change |
|---|---|
| `base/…/expertmode/ExpertModeScreen.kt` | Move debugging section inside the `Understood` branch |
| `base/…/expertmode/ExpertModeViewModel.kt` | Guard `onGetEventClick` against unacknowledged warning |
| `CHANGELOG.md` | Add entry for #2154 |

## Known limitations / areas for human review

- The GetEvent screen itself (`GetEventScreen` / `GetEventViewModel`) has no awareness of the warning state; it relies entirely on being unreachable via the UI. This is fine for the current navigation graph, but worth noting if deep-link or intent-based navigation to `NavDestination.GetEvent` is added in future.
- Unit tests could not be run locally (no Android SDK in this environment); CI will validate correctness.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jm9iJMEf72rruSfTjzDUu8)_