### PR TITLE
Edits to activity in send intent action are not saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## Fixed
 
+- #2160 edits to the activity in a send intent action are no longer discarded when the screen is
+  recreated (for example on a configuration change) before saving.
 - #2099 do not spam notifications that Expert mode failed to start on WiFi disconnection or the ADB
   pairing is broken.
 - #2220 make invisible floating buttons more visible when editing.

--- a/base/src/main/java/io/github/sds100/keymapper/base/system/intents/ConfigIntentViewModel.kt
+++ b/base/src/main/java/io/github/sds100/keymapper/base/system/intents/ConfigIntentViewModel.kt
@@ -233,6 +233,15 @@ class ConfigIntentViewModel @Inject constructor(
     private val _returnResult = MutableSharedFlow<ConfigIntentResult>()
     val returnResult = _returnResult.asSharedFlow()
 
+    /**
+     * Whether the initial [ConfigIntentResult] argument has already been applied. The fragment
+     * calls [loadResult] from onCreate, which runs again when the screen is recreated (for example
+     * on a configuration change) while this ViewModel survives. Re-applying the original argument
+     * then would discard the edits the user has made in the meantime, such as changing the chosen
+     * activity. See issue #2160.
+     */
+    private var isResultLoaded = false
+
     fun setActivityTargetChecked(isChecked: Boolean) {
         if (isChecked) {
             target.value = IntentTarget.ACTIVITY
@@ -402,6 +411,13 @@ class ConfigIntentViewModel @Inject constructor(
     }
 
     fun loadResult(result: ConfigIntentResult) {
+        // Only apply the initial argument once so that recreating the screen does not overwrite
+        // the user's edits with the original value. See issue #2160.
+        if (isResultLoaded) {
+            return
+        }
+        isResultLoaded = true
+
         val intent = Intent.parseUri(result.uri, 0)
 
         description.value = result.description

--- a/base/src/main/java/io/github/sds100/keymapper/base/system/intents/ConfigIntentViewModel.kt
+++ b/base/src/main/java/io/github/sds100/keymapper/base/system/intents/ConfigIntentViewModel.kt
@@ -233,13 +233,6 @@ class ConfigIntentViewModel @Inject constructor(
     private val _returnResult = MutableSharedFlow<ConfigIntentResult>()
     val returnResult = _returnResult.asSharedFlow()
 
-    /**
-     * Whether the initial [ConfigIntentResult] argument has already been applied. The fragment
-     * calls [loadResult] from onCreate, which runs again when the screen is recreated (for example
-     * on a configuration change) while this ViewModel survives. Re-applying the original argument
-     * then would discard the edits the user has made in the meantime, such as changing the chosen
-     * activity. See issue #2160.
-     */
     private var isResultLoaded = false
 
     fun setActivityTargetChecked(isChecked: Boolean) {
@@ -455,21 +448,37 @@ class ConfigIntentViewModel @Inject constructor(
 
             val extraType = when (value) {
                 is Boolean -> BoolExtraType
+
                 is BooleanArray -> BoolArrayExtraType
+
                 is Int -> IntExtraType
+
                 is IntArray -> IntArrayExtraType
+
                 is Long -> LongExtraType
+
                 is LongArrayExtraType -> LongArrayExtraType
+
                 is Byte -> ByteExtraType
+
                 is ByteArrayExtraType -> ByteArrayExtraType
+
                 is Double -> DoubleExtraType
+
                 is DoubleArray -> DoubleArrayExtraType
+
                 is Float -> FloatExtraType
+
                 is FloatArray -> FloatArrayExtraType
+
                 is Short -> ShortExtraType
+
                 is ShortArray -> ShortArrayExtraType
+
                 is String -> StringExtraType
+
                 is Array<*> -> StringArrayExtraType
+
                 else -> throw IllegalArgumentException(
                     "Don't know how to convert this extra (${value.javaClass.name}) to an IntentExtraType",
                 )

--- a/base/src/test/java/io/github/sds100/keymapper/base/system/intents/ConfigIntentViewModelRecreationTest.kt
+++ b/base/src/test/java/io/github/sds100/keymapper/base/system/intents/ConfigIntentViewModelRecreationTest.kt
@@ -1,0 +1,83 @@
+package io.github.sds100.keymapper.base.system.intents
+
+import android.content.Intent
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import io.github.sds100.keymapper.base.utils.ui.DialogProviderImpl
+import io.github.sds100.keymapper.base.utils.ui.FakeResourceProvider
+import io.github.sds100.keymapper.system.apps.ActivityInfo
+import io.github.sds100.keymapper.system.intents.IntentTarget
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Regression test for issue #2160. The fragment applies the initial argument by calling
+ * [ConfigIntentViewModel.loadResult] from onCreate, which runs again when the screen is recreated
+ * (for example on a configuration change) while the ViewModel survives. Loading must be applied
+ * only once so that a recreation does not discard the user's edits with the original value.
+ */
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class ConfigIntentViewModelRecreationTest {
+
+    @get:Rule
+    var instantExecutorRule = InstantTaskExecutorRule()
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var viewModel: ConfigIntentViewModel
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = ConfigIntentViewModel(FakeResourceProvider(), DialogProviderImpl())
+    }
+
+    @Test
+    fun loadResult_recreationAfterChangingActivity_keepsEditedActivity() = runTest(testDispatcher) {
+        val original = ConfigIntentResult(
+            uri = "#Intent;package=com.example.a;component=com.example.a/.MainActivity;end",
+            target = IntentTarget.ACTIVITY,
+            description = "Open App",
+            extras = emptyList(),
+        )
+
+        // Edit an existing intent action.
+        viewModel.loadResult(original)
+
+        // The user picks a different activity.
+        viewModel.setActivity(ActivityInfo("com.example.b.SecondActivity", "com.example.b"))
+
+        // The screen is recreated, so onCreate applies the original argument again.
+        viewModel.loadResult(original)
+
+        assertThat(viewModel.targetPackage.value, `is`("com.example.b"))
+        assertThat(viewModel.targetClass.value, `is`("com.example.b.SecondActivity"))
+
+        // The saved intent uri must contain the edited activity, not the original one.
+        val result = collectDoneResult()
+        val component = Intent.parseUri(result.uri, 0).component
+        assertThat(component?.packageName, `is`("com.example.b"))
+        assertThat(component?.className, `is`("com.example.b.SecondActivity"))
+    }
+
+    private suspend fun collectDoneResult(): ConfigIntentResult {
+        var result: ConfigIntentResult? = null
+        val job = kotlinx.coroutines.CoroutineScope(testDispatcher).launch {
+            result = viewModel.returnResult.first()
+        }
+        viewModel.onDoneClick()
+        job.join()
+        return result!!
+    }
+}


### PR DESCRIPTION
Closes #2160

## Summary

When editing a send intent action and changing the chosen activity, the change could be silently discarded, leaving the original activity in place after saving.

`ConfigIntentFragment` applies its argument by calling `ConfigIntentViewModel.loadResult` from `onCreate`. `onCreate` runs again whenever the screen is recreated (for example on a configuration change such as rotation, entering multi-window, or a fold) while the `ViewModel` survives. On that second run, `loadResult` re-applied the **original** argument and overwrote whatever the user had edited in the meantime — so a newly picked activity reverted to its original value.

The fix makes `loadResult` idempotent: the initial argument is applied only once, so a recreation no longer clobbers the in-progress edits held by the surviving `ViewModel`.

## Changes

- `ConfigIntentViewModel.loadResult` now applies the initial `ConfigIntentResult` argument only the first time it is called (guarded by an `isResultLoaded` flag).
- Added `ConfigIntentViewModelRecreationTest`, a regression test that loads an intent, changes the activity, simulates a recreation (a second `loadResult` with the original argument), and asserts the edited activity is preserved in both the view-model state and the produced intent URI.
- Added a `CHANGELOG.md` entry under **Fixed**.

## How it was verified

The regression test fails against the previous behaviour (activity resets to the original) and passes with the fix. Existing `ConfigIntentViewModelTest` cases and `ktlint` continue to pass.

## Notes / areas for human review

- The guard lives in the `ViewModel`, which survives configuration changes but not full process death. On process death the `ViewModel` is recreated from scratch, `isResultLoaded` resets to `false`, and the original argument is reloaded — the same behaviour as before this change (in-progress, unsaved edits are not persisted across process death; that would require a `SavedStateHandle` and is out of scope here).
- `loadResult` has a single caller (`ConfigIntentFragment.onCreate`), so making it load-once does not affect any other flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLMhZgAZLKvtgPGKXC9oKq

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLMhZgAZLKvtgPGKXC9oKq)_